### PR TITLE
Category expansion breaks Beautifier

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,2 +1,4 @@
+- <a href="https://github.com/groupby/issues/issues/920">iss5</a> Category expansion breaks Beautifier
+
 - <a href="https://github.com/groupby/issues/issues/473">iss2</a> 2 deploy apis to public repos on release
 

--- a/common/src/main/java/com/groupbyinc/api/AbstractQuery.java
+++ b/common/src/main/java/com/groupbyinc/api/AbstractQuery.java
@@ -29,6 +29,9 @@ import java.util.Map;
 public abstract class AbstractQuery<R extends AbstractRequest<R>, Q extends AbstractQuery<R, Q>> {
     private static final String DOTS = "\\.\\.";
 
+    // matches a tilde separated string
+    public static final String TILDE_REGEX = "~((?=[\\w]*[=:]))";
+
     private static <R extends AbstractRequest<R>> String requestToJson(R request) {
         try {
             return Mappers.writeValueAsString(request);
@@ -334,6 +337,13 @@ public abstract class AbstractQuery<R extends AbstractRequest<R>, Q extends Abst
         return requestToJson(request);
     }
 
+    protected String [] splitRefinements(String refinementString) {
+        if(StringUtils.isNotBlank(refinementString)) {
+            return refinementString.split(TILDE_REGEX);
+        }
+        return new String[]{};
+    }
+
     /**
      * <code>
      * A helper method to parse and set refinements.
@@ -353,7 +363,7 @@ public abstract class AbstractQuery<R extends AbstractRequest<R>, Q extends Abst
         if (refinementString == null) {
             return (Q) this;
         }
-        String[] filterStrings = refinementString.split("~");
+        String[] filterStrings = splitRefinements(refinementString);
         for (String filterString : filterStrings) {
             if (StringUtils.isBlank(filterString) || "=".equals(filterString)) {
                 continue;

--- a/common/src/test/java/com/groupbyinc/api/AbstractQueryTest.java
+++ b/common/src/test/java/com/groupbyinc/api/AbstractQueryTest.java
@@ -1,0 +1,94 @@
+package com.groupbyinc.api;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * Created by ferron on 4/22/15.
+ */
+public class AbstractQueryTest {
+
+    BaseQuery query;
+
+    @Before
+    public void setUp() {
+        query = new BaseQuery();
+    }
+
+    @Test
+    public void splitTestRange() {
+        String [] split = query.splitRefinements("test=bob~price:10..20");
+        assertArrayEquals(new String[]{"test=bob", "price:10..20"}, split);
+    }
+
+    @Test
+    public void splitTestNoCategory () {
+        String [] split = query.splitRefinements("~gender=Women~simpleColorDesc=Pink~product=Clothing");
+        assertArrayEquals(new String[]{"", "gender=Women", "simpleColorDesc=Pink", "product=Clothing"}, split);
+    }
+
+    @Test
+    public void splitTestCategory() {
+        String[] split = query.splitRefinements("~category_leaf_expanded=Category Root~Athletics~Men's~Sneakers");
+
+        assertArrayEquals(
+                new String[]{
+                        "", "category_leaf_expanded=Category Root~Athletics~Men's~Sneakers"}, split);
+    }
+
+    @Test
+    public void splitTestMultipleCategory() {
+        String[] split = query.splitRefinements("~category_leaf_expanded=Category Root~Athletics~Men's~Sneakers~category_leaf_id=580003");
+
+        assertArrayEquals(
+                new String[]{
+                        "", "category_leaf_expanded=Category Root~Athletics~Men's~Sneakers", "category_leaf_id=580003"}, split);
+    }
+
+    @Test
+    public void splitTestRangeAndMultipleCategory () {
+        String[] split = query.splitRefinements(
+                "test=bob~price:10..20~category_leaf_expanded=Category Root~Athletics~Men's" +
+                "~Sneakers~category_leaf_id=580003~color=BLUE~color=YELLOW~color=GREY");
+        assertArrayEquals(new String[]{"test=bob", "price:10..20",
+                                       "category_leaf_expanded=Category Root~Athletics~Men's~Sneakers", "category_leaf_id=580003",
+                                       "color=BLUE", "color=YELLOW", "color=GREY"}, split);
+    }
+
+    @Test
+    public void splitTestCategoryLong() {
+        String reallyLongString =
+                "~category_leaf_expanded=Category Root~Athletics~Men's~Sneakers~category_leaf_id=580003~" +
+                "color=BLUE~color=YELLOW~color=GREY~feature=Lace Up~feature=Light Weight~brand=Nike";
+
+        String [] split = query.splitRefinements(reallyLongString);
+
+        assertArrayEquals(
+                new String[]{
+                        "", "category_leaf_expanded=Category Root~Athletics~Men's~Sneakers", "category_leaf_id=580003",
+                        "color=BLUE", "color=YELLOW", "color=GREY", "feature=Lace Up", "feature=Light Weight",
+                        "brand=Nike"
+                },
+                split);
+    }
+
+    @Test
+    public void testNull () {
+        String[] split = query.splitRefinements(null);
+        assertArrayEquals(new String[]{}, split);
+    }
+
+    @Test
+    public void testEmpty () {
+        String[] split = query.splitRefinements("");
+        assertArrayEquals(new String[]{}, split);
+    }
+
+    @Test
+    public void testUtf8 () {
+        String [] split = query.splitRefinements("tëst=bäb~price:10..20");
+        assertArrayEquals(new String[]{"tëst=bäb", "price:10..20"}, split);
+    }
+}

--- a/flux/src/test/java/com/groupbyinc/util/UrlFunctionsBugTest.java
+++ b/flux/src/test/java/com/groupbyinc/util/UrlFunctionsBugTest.java
@@ -1,0 +1,55 @@
+package com.groupbyinc.util;
+
+import com.groupbyinc.api.BaseQuery;
+import com.groupbyinc.api.model.Navigation;
+import com.groupbyinc.api.model.refinement.RefinementValue;
+import com.groupbyinc.api.tags.UrlFunctions;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.jsp.JspException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by ferron on 4/22/15.
+ */
+public class UrlFunctionsBugTest {
+
+    private final String DEFAULT_BEAUTIFIER = "default";
+
+    UrlBeautifier urlBeautifier;
+
+    BaseQuery query;
+
+    @Before
+    public void setUp() {
+        query = new BaseQuery();
+        UrlBeautifier.INJECTOR.set(new HashMap<String, UrlBeautifier>());
+        UrlBeautifier.createUrlBeautifier(DEFAULT_BEAUTIFIER);
+        urlBeautifier = UrlBeautifier.getUrlBeautifiers().get(DEFAULT_BEAUTIFIER);
+        urlBeautifier.addRefinementMapping('s', "size");
+        urlBeautifier.setSearchMapping('q');
+        urlBeautifier.setAppend("/index.html");
+        urlBeautifier.addReplacementRule('/', ' ');
+        urlBeautifier.addReplacementRule('\\', ' ');
+    }
+
+    @Test
+    public void refinementAdditionWithMapping() throws JspException, AbstractUrlBeautifier.UrlBeautificationException {
+
+        List<Navigation> navigations = new ArrayList<Navigation>();
+
+        String refinementString = "Category Root~Athletics~Men's~Sneakers";
+
+        String url = UrlFunctions.toUrlAdd(
+                DEFAULT_BEAUTIFIER, "", navigations, "category_leaf_expanded", new RefinementValue().setValue(
+                        refinementString).setCount(5483));
+        assertEquals(
+                "/index.html?refinements=%7Ecategory_leaf_expanded%3DCategory+Root%7EAthletics%7EMen%27s%7ESneakers",
+                url);
+    }
+}


### PR DESCRIPTION
Created by: ferronrsmith <img height="16px" src="https://avatars.githubusercontent.com/u/159764?v=3">
Parent groupby/issues#920

If an expanded category is used as a Navigation, the refinement breaks the beautifier.

```
category3_expanded: Category Root~Athletics~Boys'
```

The beautifier breaks because the category contains tilde (~), which is used as a delimiter.
- [ ] groupby/bindle#1533
