### PR TITLE
No more reindexing

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+- <a href="https://github.com/groupby/issues/issues/965">iss6</a> No more reindexing
+
 - <a href="https://github.com/groupby/issues/issues/920">iss7</a> Category expansion breaks Beautifier
 
 - <a href="https://github.com/groupby/issues/issues/920">iss5</a> Category expansion breaks Beautifier

--- a/common/src/main/java/com/groupbyinc/api/model/Navigation.java
+++ b/common/src/main/java/com/groupbyinc/api/model/Navigation.java
@@ -15,7 +15,7 @@ import java.util.List;
  * - `id`: an MD5 hash of the name.
  * - `name`: the name of the metadata used to create this dynamic navigation option.
  * - `displayName`: the human digestible version of this name.
- * - `type`: the facet type, values of date, float, int, string.
+ * - `type`: the navigation type, Value or Range.
  * - `range`: true if the navigation option is a range.
  * - `or`: true if the navigation option supports or-queries.
  * - `refinements`: A list of the refinement values for this dynamic navigation
@@ -27,7 +27,7 @@ import java.util.List;
  */
 public class Navigation {
     public enum Type {
-        Date, Float, Integer, String, Range_Date, Range_Integer, Range_Float // NOSONAR
+        Date, Float, Integer, String, Range_Date, Range_Integer, Range_Float, Value, Range // NOSONAR
     }
 
     public enum Sort {
@@ -188,7 +188,23 @@ public class Navigation {
      * @return
      */
     public Navigation setType(Type type) {
-        this.type = type;
+        switch (type) {
+        case Value:
+        case Date:
+        case Float:
+        case Integer:
+        case String:
+            this.type = Type.Value;
+            break;
+        case Range:
+        case Range_Date:
+        case Range_Float:
+        case Range_Integer:
+            this.type = Type.Range;
+            break;
+        default:
+            this.type = type;
+        }
         return this;
     }
 


### PR DESCRIPTION
Created by: willwarren <img height="16px" src="https://avatars.githubusercontent.com/u/1261268?v=3">
Parent groupby/issues#965
## Reindex with no data

For customers like Urban outtfitters who do not do full updates, moving away from partial updates allowing re-indexing would mean that they would never be able to change a field type.
To allow partial update only clients to reindex - either:
- [ ] document a new endpoint that allows field changes and re-indexes data (0.5d)
## Points of index

Command Center (0.5d)
- [x] Change types in navigation.  --> Simple, Range 
- [x] confirm if doing a double precision range on a integer field is possible in elastic search, if yes, nothing to do, if no, need to stop them from entering decimals in the range definition.
- [ ] On save of legacy navigation, change the type to Simple / Range appropriately.

Bridge (0.5d)
- [ ] change the navigation types on load to match Simple / Range.

API (0.25d)
- [x] Breaking change to reduce the visible types to Simple / Range.
- [ ] new logic to handle old navigation types response from bridge, and the new response.

Full Upload (1d)
- [x] Support both `searchableField` and the new `field` type.

Partial Upload
- [x] Stop reindexing from partial updates - send back warning if field definitions change. (0.5d)
- [ ] move to use a header for clientKey - check with alan best practice around passing in credentials. (not sure) #973 

Elasticsearch split customer collections into separate indices.
- [ ] EngineAdmin. (3d)
  - add versioning, timestamp, collection info to the index metadata
- [ ] Stream. (1d)
- [ ] thoroughly check for all points that reference the current index. (ns)
- [ ] script to re-index from old grove to new grove. (1d)

Other (0.5d)
- [ ] Remove integer/float/date... from multi fields.
## Configuration generation endpoint (2d)

Write a new end-point that generates a configuration file based on our understanding of the data.
This end point will 
- allow a client to upload their entire data catalag but instead of streaming it into flux, will keep track of all the field value types for all field values in CSV, XML, JSON.
- For each value, try and coerce to the correct data type, int, double, string.  Keep track of the valid data types.
- after every value has been analyzed, return a configuration file with the suggested mappings.

For example, the data file:

``` coffeescript
{ title: "summer dress", variants: [ { color: "red", price:"23.99", inventory: 0, material: "jean", onSale: "true" } ]} 
```

would return 

``` coffeescript
clientKey:123412341432
field: { name: "title", type: "string", sortable: true }
field: { name: "variants.color", type: "string", sortable: true }
field: { name: "variants.price", type: "double", sortable: true }
field: { name: "variants.inventory", type: "integer", sortable: true }
field: { name: "variants.material", type: "string", sortable: true }
field: { name: "variants.onSale", type: "boolean", sortable: true }
```
