### PR TITLE
Category expansion breaks Beautifier

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+- <a href="https://github.com/groupby/issues/issues/920">iss7</a> Category expansion breaks Beautifier
+
 - <a href="https://github.com/groupby/issues/issues/920">iss5</a> Category expansion breaks Beautifier
 
 - <a href="https://github.com/groupby/issues/issues/473">iss2</a> 2 deploy apis to public repos on release

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -37,6 +37,12 @@
       <version>${groupbyinc.common.version}</version>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>net.sourceforge.jregex</groupId>
+      <artifactId>jregex</artifactId>
+      <version>${jregex.version}</version>
+    </dependency>
+
 
     <!-- ### Test -->
     <dependency>

--- a/common/src/main/java/com/groupbyinc/api/AbstractQuery.java
+++ b/common/src/main/java/com/groupbyinc/api/AbstractQuery.java
@@ -7,14 +7,16 @@ import com.groupbyinc.api.model.Sort;
 import com.groupbyinc.api.model.refinement.RefinementRange;
 import com.groupbyinc.api.model.refinement.RefinementValue;
 import com.groupbyinc.api.parser.Mappers;
-import com.groupbyinc.api.request.RefinementsRequest;
 import com.groupbyinc.api.request.AbstractRequest;
+import com.groupbyinc.api.request.RefinementsRequest;
 import com.groupbyinc.api.request.RestrictNavigation;
 import com.groupbyinc.api.request.SelectedRefinement;
 import com.groupbyinc.api.request.refinement.SelectedRefinementRange;
 import com.groupbyinc.api.request.refinement.SelectedRefinementValue;
 import com.groupbyinc.common.util.collections4.CollectionUtils;
 import com.groupbyinc.common.util.lang3.StringUtils;
+import jregex.Pattern;
+import jregex.RETokenizer;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -337,10 +339,12 @@ public abstract class AbstractQuery<R extends AbstractRequest<R>, Q extends Abst
         return requestToJson(request);
     }
 
-    protected String [] splitRefinements(String refinementString) {
-        if(StringUtils.isNotBlank(refinementString)) {
-            return refinementString.split(TILDE_REGEX);
-        }
+    protected String[] splitRefinements(String refinementString) {
+        if (StringUtils.isNotBlank(refinementString)) {
+            Pattern pattern = new Pattern(TILDE_REGEX);
+            RETokenizer tokenizer = pattern.tokenizer(refinementString);
+            return tokenizer.split();
+        }   
         return new String[]{};
     }
 

--- a/common/src/test/java/com/groupbyinc/api/AbstractQueryTest.java
+++ b/common/src/test/java/com/groupbyinc/api/AbstractQueryTest.java
@@ -26,7 +26,7 @@ public class AbstractQueryTest {
     @Test
     public void splitTestNoCategory () {
         String [] split = query.splitRefinements("~gender=Women~simpleColorDesc=Pink~product=Clothing");
-        assertArrayEquals(new String[]{"", "gender=Women", "simpleColorDesc=Pink", "product=Clothing"}, split);
+        assertArrayEquals(new String[]{"gender=Women", "simpleColorDesc=Pink", "product=Clothing"}, split);
     }
 
     @Test
@@ -34,8 +34,7 @@ public class AbstractQueryTest {
         String[] split = query.splitRefinements("~category_leaf_expanded=Category Root~Athletics~Men's~Sneakers");
 
         assertArrayEquals(
-                new String[]{
-                        "", "category_leaf_expanded=Category Root~Athletics~Men's~Sneakers"}, split);
+                new String[]{"category_leaf_expanded=Category Root~Athletics~Men's~Sneakers"}, split);
     }
 
     @Test
@@ -43,8 +42,7 @@ public class AbstractQueryTest {
         String[] split = query.splitRefinements("~category_leaf_expanded=Category Root~Athletics~Men's~Sneakers~category_leaf_id=580003");
 
         assertArrayEquals(
-                new String[]{
-                        "", "category_leaf_expanded=Category Root~Athletics~Men's~Sneakers", "category_leaf_id=580003"}, split);
+                new String[]{"category_leaf_expanded=Category Root~Athletics~Men's~Sneakers", "category_leaf_id=580003"}, split);
     }
 
     @Test
@@ -66,8 +64,7 @@ public class AbstractQueryTest {
         String [] split = query.splitRefinements(reallyLongString);
 
         assertArrayEquals(
-                new String[]{
-                        "", "category_leaf_expanded=Category Root~Athletics~Men's~Sneakers", "category_leaf_id=580003",
+                new String[]{"category_leaf_expanded=Category Root~Athletics~Men's~Sneakers", "category_leaf_id=580003",
                         "color=BLUE", "color=YELLOW", "color=GREY", "feature=Lace Up", "feature=Light Weight",
                         "brand=Nike"
                 },

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <junit.version>4.12</junit.version>
     <cloning.util.version>1.9.2</cloning.util.version>
     <groupbyinc.common.version>24</groupbyinc.common.version>
+    <jregex.version>1.2_01</jregex.version>
 
     <!-- ### Test -->
     <test.runOrder>random</test.runOrder>


### PR DESCRIPTION
Created by: ferronrsmith <img height="16px" src="https://avatars.githubusercontent.com/u/159764?v=3">
Parent groupby/issues#920

If an expanded category is used as a Navigation, the refinement breaks the beautifier.

```
category3_expanded: Category Root~Athletics~Boys'
```

The beautifier breaks because the category contains tilde (~), which is used as a delimiter.
- [x] groupby/bindle#1533
- [x] groupby/api-java#5
- [x] groupby/api-php#14
